### PR TITLE
Added utf-8 decoding to http response

### DIFF
--- a/lib/open_graph_parser.dart
+++ b/lib/open_graph_parser.dart
@@ -2,6 +2,7 @@ import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 import 'package:html/dom.dart';
 import 'dart:async';
+import 'dart:convert';
 
 class OpenGraphParser {
   /// Defines a map with all open-graph tags from a given website

--- a/lib/open_graph_parser.dart
+++ b/lib/open_graph_parser.dart
@@ -19,7 +19,7 @@ class OpenGraphParser {
     var data = {};
 
     if (response.statusCode == 200) {
-      var document = parser.parse(response.body);
+      var document = parser.parse(utf8.decode(response.bodyBytes));
       var openGraphMetaTags = _getOpenGraphData(document);
 
       openGraphMetaTags.forEach((element) {


### PR DESCRIPTION
Some characters are not correctly decoded, adding utf-8 decoding for the http.response fixes that.